### PR TITLE
Fix for user-specified installation paths

### DIFF
--- a/condacolab.py
+++ b/condacolab.py
@@ -116,6 +116,9 @@ def install_from_url(
 
     print("🩹 Patching environment...")
     env = env or {}
+    bin_path = f"{prefix}/bin"
+    if bin_path not in os.environ["PATH"]:
+        env["PATH"] = f'"{bin_path}:$PATH"'
     env["LD_LIBRARY_PATH"] = f'"{prefix}/lib:$LD_LIBRARY_PATH"'
 
     os.rename(sys.executable, f"{sys.executable}.real")
@@ -282,6 +285,9 @@ def check(prefix: os.PathLike = PREFIX, verbose: bool = True):
     pymaj, pymin = sys.version_info[:2]
     sitepackages = f"{prefix}/lib/python{pymaj}.{pymin}/site-packages"
     assert sitepackages in sys.path, f"💥💔💥 PYTHONPATH was not patched! Value: {sys.path}"
+    assert (
+        f"{prefix}/bin" in os.environ["PATH"]
+    ), f"💥💔💥 PATH was not patched! Value: {os.environ['PATH']}"
     assert (
         f"{prefix}/lib" in os.environ["LD_LIBRARY_PATH"]
     ), f"💥💔💥 LD_LIBRARY_PATH was not patched! Value: {os.environ['LD_LIBRARY_PATH']}"

--- a/condacolab.py
+++ b/condacolab.py
@@ -117,9 +117,9 @@ def install_from_url(
     print("🩹 Patching environment...")
     env = env or {}
     bin_path = f"{prefix}/bin"
-    if bin_path not in os.environ["PATH"]:
-        env["PATH"] = f'"{bin_path}:$PATH"'
-    env["LD_LIBRARY_PATH"] = f'"{prefix}/lib:$LD_LIBRARY_PATH"'
+    if bin_path not in os.environ.get("PATH", "").split(":"):
+        env["PATH"] = f"{bin_path}:{os.environ.get('PATH', '')}"
+    env["LD_LIBRARY_PATH"] = f"{prefix}/lib:{os.environ.get('LD_LIBRARY_PATH', '')}"
 
     os.rename(sys.executable, f"{sys.executable}.real")
     with open(sys.executable, "w") as f:


### PR DESCRIPTION
Hi @jaimergp, this is a great package. Thanks for developing it.
Please allow me to propose a bug fix for setting the target location of the conda installation.

## Description
The bug is if a user specifies the installation target location using the `prefix` parameter in any of the install functions, the `check()` will fail because the conda executable won't be found. This occurs because the bin directory containing the conda executable is not in the system $PATH variable.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - This PR fixes the bug by patching the /prefix/bin directory into the os environment $PATH when the kernal restarted.
  - It also adds a check that the $PATH has been successfully updated into the `check()` function. This might not be necessary as the `assert find_executable("conda")` already exists, but I added it anyway to be safe.

## Questions
- N/A

## Status
- Ready to go